### PR TITLE
Unused variable removal wrt #125

### DIFF
--- a/src/unit_tests/02_Tweeting.cpp
+++ b/src/unit_tests/02_Tweeting.cpp
@@ -53,7 +53,6 @@ SUITE(TweetStore) {
                 } else {
                     elemsB.push_back(elem);
                 }
-                int r = vec_tree.pick_random_weighted(rng);
             }
             //vec_tree.print();
             for (int i = 0; i < elemsA.size(); i++) {


### PR DESCRIPTION
Removing unused variable `int r = vec_tree.pick_random_weighted(rng)` at [src/unit_tests/02_Tweeting.cpp#L56](https://github.com/hashkat/hashkat/blob/master/src/unit_tests/02_Tweeting.cpp#L56) wrt #125