### PR TITLE
Unused variable removal #L442 wrt #125

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -439,7 +439,6 @@ void model_match(Network& network, vector<int> & counts, int max_degree) {
        sum_k += network.n_followers(i);
        sum_k += network.n_followings(i); 
     }
-    double average_degree = (double)sum_k / (double)network.size();
     double sum_jN = 0;
     for (int j = 0; j < counts.size(); j++) {
         sum_jN += j*counts[j];


### PR DESCRIPTION
Unused variable removal `double average_degree = (double)sum_k / (double)network.size()` [src/io.cpp#L442](https://github.com/hashkat/hashkat/blob/master/src/io.cpp#L442) wrt #125